### PR TITLE
Fix missing type leading to StackOverflow

### DIFF
--- a/src/quantileregression.jl
+++ b/src/quantileregression.jl
@@ -114,7 +114,7 @@ function fit(
     dofit::Bool=true,
     wts::FPVector=similar(y, 0),
     fitdispersion::Bool=false,
-    fitargs...,
+    fitargs...
 ) where {M<:QuantileRegression,T<:AbstractFloat}
 
     # Check that X and y have the same number of observations
@@ -133,10 +133,10 @@ end
 
 function fit(
     ::Type{M},
-    X::Union{AbstractMatrix,SparseMatrixCSC},
-    y::AbstractVector;
-    kwargs...,
-) where {M<:QuantileRegression}
+    X::Union{AbstractMatrix{T1},SparseMatrixCSC{T1}},
+    y::AbstractVector{T2};
+    kwargs...
+) where {M<:QuantileRegression,T1<:Real,T2<:Real}
     fit(M, float(X), float(y); kwargs...)
 end
 
@@ -171,7 +171,7 @@ function refit!(
     m::QuantileRegression{T};
     quantile::Union{Nothing,AbstractFloat}=nothing,
     wts::Union{Nothing,FPVector}=nothing,
-    kwargs...,
+    kwargs...
 ) where {T}
 
     # Update wts
@@ -210,7 +210,7 @@ function fit!(
     verbose::Bool=false,
     quantile::Union{Nothing,AbstractFloat}=nothing,
     correct_leverage::Bool=false,
-    kwargs...,
+    kwargs...
 ) where {T}
 
     # Return early if model has the fit flag set
@@ -254,13 +254,13 @@ function interiormethod!(βout, rout, X, y, τ; wts=[], verbose::Bool=false)
     u = Vector{Int}(undef, n)
     v = Vector{Int}(undef, n)
     for i in 1:p
-        β[i] = Tulip.add_variable!(pb, Int[], Float64[], 0.0 , -Inf , Inf, "β$i")
+        β[i] = Tulip.add_variable!(pb, Int[], Float64[], 0.0, -Inf, Inf, "β$i")
     end
     for i in 1:n
-        u[i] = Tulip.add_variable!(pb, Int[], Float64[], τ   ,  0.0 , Inf, "u$i")
+        u[i] = Tulip.add_variable!(pb, Int[], Float64[], τ, 0.0, Inf, "u$i")
     end
     for i in 1:n
-        v[i] = Tulip.add_variable!(pb, Int[], Float64[], 1-τ ,  0.0 , Inf, "v$i")
+        v[i] = Tulip.add_variable!(pb, Int[], Float64[], 1 - τ, 0.0, Inf, "v$i")
     end
     #    @variable(model, β[1:p])
     #    @variable(model, u[1:n] >= 0)
@@ -392,7 +392,7 @@ function sparcity(
     m::QuantileRegression;
     bw_method::Symbol=:jones,
     α::Real=0.05,
-    kernel::Symbol=:epanechnikov,
+    kernel::Symbol=:epanechnikov
 )
     u = m.τ
     n = nobs(m)
@@ -405,7 +405,7 @@ function sparcity(
         hall_sheather_bandwidth(u, n, α)
     else
         error(
-            "only :jones, :bofinger and :hall_sheather methods for estimating the"*
+            "only :jones, :bofinger and :hall_sheather methods for estimating the" *
             " optimal bandwidth are allowed: $(bw_method)",
         )
     end
@@ -442,7 +442,7 @@ function location_variance(
     sqr::Bool=false;
     bw_method::Symbol=:jones,
     α::Real=0.05,
-    kernel::Symbol=:epanechnikov,
+    kernel::Symbol=:epanechnikov
 )
     v = sparcity(m; bw_method=bw_method, α=α, kernel=kernel)^2
     v *= m.τ * (1 - m.τ)

--- a/src/quantileregression.jl
+++ b/src/quantileregression.jl
@@ -133,10 +133,10 @@ end
 
 function fit(
     ::Type{M},
-    X::Union{AbstractMatrix,SparseMatrixCSC},
-    y::AbstractVector;
+    X::Union{AbstractMatrix{T1},SparseMatrixCSC{T1}},
+    y::AbstractVector{T2};
     kwargs...,
-) where {M<:QuantileRegression}
+) where {M<:QuantileRegression,T1<:Real,T2<:Real}
     fit(M, float(X), float(y); kwargs...)
 end
 

--- a/src/quantileregression.jl
+++ b/src/quantileregression.jl
@@ -114,7 +114,7 @@ function fit(
     dofit::Bool=true,
     wts::FPVector=similar(y, 0),
     fitdispersion::Bool=false,
-    fitargs...
+    fitargs...,
 ) where {M<:QuantileRegression,T<:AbstractFloat}
 
     # Check that X and y have the same number of observations
@@ -133,10 +133,10 @@ end
 
 function fit(
     ::Type{M},
-    X::Union{AbstractMatrix{T1},SparseMatrixCSC{T1}},
-    y::AbstractVector{T2};
-    kwargs...
-) where {M<:QuantileRegression,T1<:Real,T2<:Real}
+    X::Union{AbstractMatrix,SparseMatrixCSC},
+    y::AbstractVector;
+    kwargs...,
+) where {M<:QuantileRegression}
     fit(M, float(X), float(y); kwargs...)
 end
 
@@ -171,7 +171,7 @@ function refit!(
     m::QuantileRegression{T};
     quantile::Union{Nothing,AbstractFloat}=nothing,
     wts::Union{Nothing,FPVector}=nothing,
-    kwargs...
+    kwargs...,
 ) where {T}
 
     # Update wts
@@ -210,7 +210,7 @@ function fit!(
     verbose::Bool=false,
     quantile::Union{Nothing,AbstractFloat}=nothing,
     correct_leverage::Bool=false,
-    kwargs...
+    kwargs...,
 ) where {T}
 
     # Return early if model has the fit flag set
@@ -254,13 +254,13 @@ function interiormethod!(βout, rout, X, y, τ; wts=[], verbose::Bool=false)
     u = Vector{Int}(undef, n)
     v = Vector{Int}(undef, n)
     for i in 1:p
-        β[i] = Tulip.add_variable!(pb, Int[], Float64[], 0.0, -Inf, Inf, "β$i")
+        β[i] = Tulip.add_variable!(pb, Int[], Float64[], 0.0 , -Inf , Inf, "β$i")
     end
     for i in 1:n
-        u[i] = Tulip.add_variable!(pb, Int[], Float64[], τ, 0.0, Inf, "u$i")
+        u[i] = Tulip.add_variable!(pb, Int[], Float64[], τ   ,  0.0 , Inf, "u$i")
     end
     for i in 1:n
-        v[i] = Tulip.add_variable!(pb, Int[], Float64[], 1 - τ, 0.0, Inf, "v$i")
+        v[i] = Tulip.add_variable!(pb, Int[], Float64[], 1-τ ,  0.0 , Inf, "v$i")
     end
     #    @variable(model, β[1:p])
     #    @variable(model, u[1:n] >= 0)
@@ -392,7 +392,7 @@ function sparcity(
     m::QuantileRegression;
     bw_method::Symbol=:jones,
     α::Real=0.05,
-    kernel::Symbol=:epanechnikov
+    kernel::Symbol=:epanechnikov,
 )
     u = m.τ
     n = nobs(m)
@@ -405,7 +405,7 @@ function sparcity(
         hall_sheather_bandwidth(u, n, α)
     else
         error(
-            "only :jones, :bofinger and :hall_sheather methods for estimating the" *
+            "only :jones, :bofinger and :hall_sheather methods for estimating the"*
             " optimal bandwidth are allowed: $(bw_method)",
         )
     end
@@ -442,7 +442,7 @@ function location_variance(
     sqr::Bool=false;
     bw_method::Symbol=:jones,
     α::Real=0.05,
-    kernel::Symbol=:epanechnikov
+    kernel::Symbol=:epanechnikov,
 )
     v = sparcity(m; bw_method=bw_method, α=α, kernel=kernel)^2
     v *= m.τ * (1 - m.τ)

--- a/src/robustlinearmodel.jl
+++ b/src/robustlinearmodel.jl
@@ -367,11 +367,11 @@ end
 
 function fit(
     ::Type{M},
-    X::Union{AbstractMatrix,SparseMatrixCSC},
-    y::AbstractVector,
+    X::Union{AbstractMatrix{T1},SparseMatrixCSC{T1}},
+    y::AbstractVector{T2},
     est::AbstractEstimator;
     kwargs...,
-) where {M<:AbstractRobustModel}
+) where {M<:AbstractRobustModel,T1<:Real,T2<:Real}
     fit(M, float(X), float(y), est; kwargs...)
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -103,6 +103,14 @@ funcs = ( dof,
         @test all(0 .== coef(m2))
         fit!(m2; verbose=false, initial_scale=:mad)
         @test all(β .== coef(m2))
+
+        @testset "Handling of missing values" begin
+            # check that Missing eltype is routed correctly
+            X_missing=convert(Matrix{Union{Missing,eltype(X)}},X)
+            y_missing=convert(Vector{Union{Missing,eltype(y)}},y)
+            @test_throws MethodError fit(RobustLinearModel,X_missing,y,est1)
+            @test_throws MethodError fit(RobustLinearModel,X,y_missing,est1)
+        end
     end
 end
 

--- a/test/qreg.jl
+++ b/test/qreg.jl
@@ -55,6 +55,14 @@ end
         # leverage weights
         @test_nowarn refit!(m3; correct_leverage=true)
     end
+
+    @testset "Handling of missing values" begin
+        # check that Missing eltype is routed correctly
+        X_missing=convert(Matrix{Union{Missing,eltype(X)}},X)
+        y_missing=convert(Vector{Union{Missing,eltype(y)}},y)
+        @test_throws MethodError fit(QuantileRegression,X_missing,y)
+        @test_throws MethodError fit(QuantileRegression,X,y_missing)
+    end
 end
 
 @testset "Quantile regression: different quantiles" begin


### PR DESCRIPTION
Fixes https://github.com/getzze/RobustModels.jl/issues/16

I've narrowed the generic `fit(..,AbstractMatrix,...)` method to numeric eltypes only (`fit(...,AbstractMatrix{<:Real},...)`) to make sure Missing type does not get accepted (to prevent the infinite loop of calling `float(X)` on the inputs).

Now the function correctly returns `MethodError` when a matrix with Missing eltype is provided as an input.

If this solution is acceptable, I'd ensure consistency with the rest of the code base (I see the same issue in more places, eg, https://github.com/getzze/RobustModels.jl/blob/8332434619438b7edf5798041cc820069417cb77/src/robustlinearmodel.jl#L375)