### PR TITLE
Fixes for docs and `show` methods

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -12,3 +12,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsModels = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+
+[sources]
+RobustModels = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,9 @@ DocMeta.setdocmeta!(
     :(using RobustModels, StatsBase, GLM, StatsAPI);
     recursive=true,
 )
+DocMeta.setdocmeta!(StatsBase, :DocTestSetup, :(using StatsBase); recursive=true)
+DocMeta.setdocmeta!(GLM, :DocTestSetup, :(using GLM, StatsBase); recursive=true)
+DocMeta.setdocmeta!(StatsAPI, :DocTestSetup, :(using StatsAPI); recursive=true)
 
 prettyurls = get(ENV, "CI", "false") == "true"
 

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -8,7 +8,10 @@ end
 ```
 
 ## Robust linear regression
-```jldoctest
+
+Here we show examples fitting simple data with ``Y = 2X`` in the presence of outliers. We first use the [`MEstimator`](@ref) with the [`L2Loss`](@ref) function.
+
+```jldoctest example
 julia> using DataFrames, RobustModels
 
 julia> data = DataFrame(X=[1,2,3,4,5,6], Y=[2,4,7,8,9,13])
@@ -49,7 +52,11 @@ julia> round.(predict(ols), digits=5)
   8.18095
  10.20952
  12.2381
+```
 
+Now we add an additional outlier and we estimate the model parameters with the [`MMEstimator`](@ref) using the [`TukeyLoss`](@ref) function.
+
+```jldoctest example
 julia> data[5, :Y] = 1; data
 6×2 DataFrame
  Row │ X      Y
@@ -62,7 +69,7 @@ julia> data[5, :Y] = 1; data
    5 │     5      1
    6 │     6     13
 
-julia> rob = rlm(@formula(Y ~ X), data, MMEstimator{TukeyLoss}(); σ0=:mad)
+julia> rlm(@formula(Y ~ X), data, MMEstimator{TukeyLoss}(); σ0=:mad)
 Robust regression with MM-Estimator(TukeyLoss(1.5476), TukeyLoss(4.685))
 
 Y ~ 1 + X
@@ -74,5 +81,21 @@ Coefficients:
 (Intercept)  -0.184561    0.514249  -0.36    0.7378   -1.61235    1.24322
 X             2.18005     0.14112   15.45    0.0001    1.78824    2.57186
 ─────────────────────────────────────────────────────────────────────────
+```
 
+And now with the [`SEstimator`](@ref) using the [`TukeyLoss`](@ref) function.
+
+```jldoctest example
+julia> rlm(@formula(Y ~ X), data, SEstimator{TukeyLoss}(); σ0=:mad)
+Robust regression with S-Estimator(TukeyLoss(1.5476))
+
+Y ~ 1 + X
+
+Coefficients:
+─────────────────────────────────────────────────────────────────────────
+                 Coef.  Std. Error      t  Pr(>|t|)  Lower 95%  Upper 95%
+─────────────────────────────────────────────────────────────────────────
+(Intercept)  -0.331551    0.393179  -0.84    0.4466   -1.42319   0.760088
+X             2.20275     0.105577  20.86    <1e-04    1.90962   2.49588
+─────────────────────────────────────────────────────────────────────────
 ```

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -247,7 +247,7 @@ The S-estimator is obtained by minimizing the scale estimate:
 \\hat{\\mathbf{\\beta}} = \\underset{\\mathbf{\\beta}}{\\textrm{argmin }} \\hat{\\sigma}^2
 ```
 
-where the robust scale estimate ``\\hat{\\sigma}}`` is solution of:
+where the robust scale estimate ``\\hat{\\sigma}`` is solution of:
 
 
 ```math

--- a/src/estimators.jl
+++ b/src/estimators.jl
@@ -309,7 +309,7 @@ The MM-estimator is obtained using a two-step process:
 # Fields
 - `loss1`: the [`BoundedLossFunction`](@ref) used for the high breakdown point S-estimation.
 - `loss2`: the [`LossFunction`](@ref) used for the efficient M-estimation.
-- `scaleest`: boolean specifying the if the estimation is in the S-estimation step (`true`)
+- `scaleest`: boolean specifying the if the estimation is in the S-estimation step (`true`) \
 or the M-estimation step (`false`).
 
 """

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -492,7 +492,7 @@ estimator_high_breakdown_point_constant(::Type{WelschLoss}) = 0.8165
 
 """
 The non-convex Tukey biweight estimator which completely suppresses the outliers,
-and does not guaranty a unique solution.
+and does not guarantee a unique solution.
 ψ(r) = (abs(r) <= 1) ? r * (1 - r^2)^2 : 0
 """
 struct TukeyLoss <: BoundedLossFunction

--- a/src/quantileregression.jl
+++ b/src/quantileregression.jl
@@ -51,8 +51,10 @@ function Base.show(io::IO, obj::QuantileRegression)
     if hasformula(obj)
         msg *= "$(formula(obj))\n\n"
     end
-    msg *= "Coefficients:\n"
-    return println(io, msg, coeftable(obj))
+    msg *= "Coefficients:"
+    println(io, msg)
+    show(io, MIME"text/plain"(), coeftable(obj))
+    return nothing
 end
 
 """

--- a/src/robustlinearmodel.jl
+++ b/src/robustlinearmodel.jl
@@ -197,10 +197,11 @@ function Base.show(io::IO, obj::RobustLinearModel)
     if hasformula(obj)
         msg *= "$(formula(obj))\n\n"
     end
-    msg *= "Coefficients:\n"
-    return println(io, msg, coeftable(obj))
+    msg *= "Coefficients:"
+    println(io, msg)
+    show(io, MIME"text/plain"(), coeftable(obj))
+    return nothing
 end
-
 
 hasformula(m::RobustLinearModel) = isnothing(m.formula) ? false : true
 


### PR DESCRIPTION
I was checking this package out (very cool!) and found a few issues with the documentation that this fixes. Some are minor typo fixes, two larger changes are described below

- The doctest in `docs/src/examples.md` that show the `RobustLinearModel` were failing because the CoefsTable part was not displaying correctly. I fixed this for both `RobustLinearModel` and `QuantileRegression` types. 
- The doctests that get run for StatsBase were erroring because they were not finding methods exported from StatsBase. I fixed this by adding doctestsetup steps for the other packages included in `modules` for `Documenter.make`.

The docs now successfully build for me locally (Julia v1.12), my docs environment looks like 

> Status `~/Development/julia/RobustModels.jl/docs/Project.toml`
  [324d7699] CategoricalArrays v1.1.0
  [a93c6f00] DataFrames v1.8.1
  [31c24e10] Distributions v0.25.123
  [e30172f5] Documenter v1.17.0
  [38e38edf] GLM v1.9.3
  [ce6b1742] RDatasets v0.8.1
  [d6ea1423] RobustModels v0.6.0 `..`
  [10745b16] Statistics v1.11.1
  [82ae8749] StatsAPI v1.8.0
  [2913bbd2] StatsBase v0.34.10
  [3eaba693] StatsModels v0.7.9
  [37e2e46d] LinearAlgebra v1.12.0
  [2f01184e] SparseArrays v1.12.0